### PR TITLE
Added omit_defaults and code simplifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ optional arguments:
   --config_path str    Path for a config file to parse with pyrallis (default:
                   None)
 
-TrainConfig ['options']:
+TrainConfig:
    Training config for Machine Learning
 
   --workers int   The number of workers for training (default: 8)
@@ -360,6 +360,6 @@ The `pyrallis.field` behaves like the regular `dataclasses.field` with an additi
 # TODOs:
 - [ ] Fix error with default Dict and List
 >         Underlying error: No decoding function for type ~KT, consider using pyrallis.decode.register
-- [ ] Refine the `--help` command
+- [x] Refine the `--help` command
 > For example the `options` argument is confusing there
 - [ ] Add a test to `omit_defaults`

--- a/README.md
+++ b/README.md
@@ -362,3 +362,4 @@ The `pyrallis.field` behaves like the regular `dataclasses.field` with an additi
 >         Underlying error: No decoding function for type ~KT, consider using pyrallis.decode.register
 - [ ] Refine the `--help` command
 > For example the `options` argument is confusing there
+- [ ] Add a test to `omit_defaults`

--- a/docs/api.md
+++ b/docs/api.md
@@ -382,7 +382,7 @@ The `pathlib.Path` type is useful for path manipulation, and hence a useful type
 
 ### pyrallis.dump
 ```python
-def dump(config: Dataclass, stream=None, *args, **kwargs)
+def dump(config: Dataclass, stream=None, omit_defaults: bool = False, **kwargs)
 ```
 Serialize a configuration dataclass into a YAML stream. If stream is None, return the produced string instead. Additional arguments are passed along to `yaml.dump`.
 In practice this function uses pyrallis.encode to create a standard dictionary from the dataclass which is then passed along to `yaml`.
@@ -390,6 +390,7 @@ In practice this function uses pyrallis.encode to create a standard dictionary f
 > Parameters
 
 * **config (dataclass)** - The dataclass to serialize
+* **omit_defaults** - If true, does not dump values that are equal to the default Dataclass values.
 * **stream** - An output stream to dump into. If None, the produced string is returned.
 
 

--- a/pyrallis/parsers/encoding.py
+++ b/pyrallis/parsers/encoding.py
@@ -20,6 +20,8 @@ from typing import Any, Dict, Hashable, TypeVar
 
 import yaml
 
+from pyrallis import utils
+
 logger = getLogger(__name__)
 
 
@@ -117,6 +119,13 @@ encode.register(Namespace, lambda x: encode(vars(x)))
 Dataclass = TypeVar("Dataclass")
 
 
-def dump(config: Dataclass, *args, **kwargs):
+def dump(config: Dataclass, stream=None, omit_defaults: bool = False, *args, **kwargs):
+    """
+    Dump the config file to yaml.
+    optionally omit any value that still has a default value
+    """
     config_dict = encode(config)
-    return yaml.dump(config_dict, *args, **kwargs)
+    if omit_defaults:
+        defaults_dict = encode(utils.get_defaults_dict(config))
+        config_dict = utils.remove_matching(config_dict, defaults_dict)
+    return yaml.dump(config_dict, stream, *args, **kwargs)

--- a/pyrallis/parsers/encoding.py
+++ b/pyrallis/parsers/encoding.py
@@ -119,7 +119,7 @@ encode.register(Namespace, lambda x: encode(vars(x)))
 Dataclass = TypeVar("Dataclass")
 
 
-def dump(config: Dataclass, stream=None, omit_defaults: bool = False, *args, **kwargs):
+def dump(config: Dataclass, stream=None, omit_defaults: bool = False, **kwargs):
     """
     Dump the config file to yaml.
     optionally omit any value that still has a default value
@@ -128,4 +128,4 @@ def dump(config: Dataclass, stream=None, omit_defaults: bool = False, *args, **k
     if omit_defaults:
         defaults_dict = encode(utils.get_defaults_dict(config))
         config_dict = utils.remove_matching(config_dict, defaults_dict)
-    return yaml.dump(config_dict, stream, *args, **kwargs)
+    return yaml.dump(config_dict, stream, **kwargs)

--- a/pyrallis/utils.py
+++ b/pyrallis/utils.py
@@ -573,12 +573,12 @@ def deflatten(d: Dict[str, Any], parent_key: str = '.', sep: str = '.'):
 
 
 def remove_matching(dict_a, dict_b):
-    dict_a = flatten(dict_a)
-    dict_b = flatten(dict_b)
+    dict_a = flatten(dict_a, parent_key=BASE_KEY)
+    dict_b = flatten(dict_b, parent_key=BASE_KEY)
     for key in dict_b:
         if key in dict_a and dict_b[key] == dict_a[key]:
             del dict_a[key]
-    return deflatten(dict_a)
+    return deflatten(dict_a, parent_key=BASE_KEY)
 
 
 BASE_KEY = 'options'

--- a/pyrallis/utils.py
+++ b/pyrallis/utils.py
@@ -548,21 +548,21 @@ def keep_keys(d: Dict, keys_to_keep: Iterable[str]) -> Tuple[Dict, Dict]:
     return d, removed
 
 
-def flatten(d, parent_key='', sep='.'):
+def flatten(d, parent_key=None, sep='.'):
     items = []
     for k, v in d.items():
         new_key = parent_key + sep + k if parent_key else k
         if isinstance(v, c_abc.MutableMapping):
-            items.extend(flatten(v, new_key, sep=sep).items())
+            items.extend(flatten(v, parent_key=new_key, sep=sep).items())
         else:
             items.append((new_key, v))
     return dict(items)
 
 
-def deflatten(d: Dict[str, Any], parent_key: str = '.', sep: str = '.'):
+def deflatten(d: Dict[str, Any], sep: str = '.'):
     deflat_d = {}
     for key in d:
-        key_parts = key[len(parent_key) + 1:].split(sep)
+        key_parts = key.split(sep)
         curr_d = deflat_d
         for inner_key in key_parts[:-1]:
             if not inner_key in curr_d:
@@ -573,15 +573,14 @@ def deflatten(d: Dict[str, Any], parent_key: str = '.', sep: str = '.'):
 
 
 def remove_matching(dict_a, dict_b):
-    dict_a = flatten(dict_a, parent_key=BASE_KEY)
-    dict_b = flatten(dict_b, parent_key=BASE_KEY)
+    dict_a = flatten(dict_a)
+    dict_b = flatten(dict_b)
     for key in dict_b:
         if key in dict_a and dict_b[key] == dict_a[key]:
             del dict_a[key]
-    return deflatten(dict_a, parent_key=BASE_KEY)
+    return deflatten(dict_a)
 
 
-BASE_KEY = 'options'
 CONFIG_ARG = 'config_path'
 
 if __name__ == "__main__":

--- a/pyrallis/wrappers/wrapper.py
+++ b/pyrallis/wrappers/wrapper.py
@@ -15,6 +15,8 @@ class Wrapper(Generic[T], ABC):
     def dest(self) -> str:
         """Where the attribute will be stored in the Namespace."""
         lineage_names: List[str] = [w.name for w in self.lineage()]
+        if lineage_names[-1] is None:  # Skip root if None
+            lineage_names = lineage_names[:-1]
         self._dest = ".".join(reversed([self.name] + lineage_names))
         assert self._dest is not None
         return self._dest

--- a/pyrallis/wrappers/wrapper.py
+++ b/pyrallis/wrappers/wrapper.py
@@ -14,11 +14,12 @@ class Wrapper(Generic[T], ABC):
     @property
     def dest(self) -> str:
         """Where the attribute will be stored in the Namespace."""
+        if self.parent is None:
+            return self.name
         lineage_names: List[str] = [w.name for w in self.lineage()]
-        if lineage_names[-1] is None:  # Skip root if None
+        if lineage_names[-1] is None: # root usually won't have a name
             lineage_names = lineage_names[:-1]
         self._dest = ".".join(reversed([self.name] + lineage_names))
-        assert self._dest is not None
         return self._dest
 
     def lineage(self) -> List["Wrapper"]:


### PR DESCRIPTION
Implemented the suggestion from issue #1 to add an `omit_defaults` option to the dump function
```python
pyrallis.dump(cfg, omit_defaults=True)
```

Also simplified the wrapper classes in the process and improved the --help command to be more concise.