### PR TITLE
Changed enum parsing mechanism to be name based

### DIFF
--- a/pyrallis/parsers/decoding.py
+++ b/pyrallis/parsers/decoding.py
@@ -163,7 +163,7 @@ def get_decoding_fn(t: Type[T]) -> Callable[[Any], T]:
         return decode_union(*args)
 
     elif is_enum(t):
-        return t
+        return lambda key: t[key]
 
     import typing_inspect as tpi
 

--- a/pyrallis/parsers/decoding.py
+++ b/pyrallis/parsers/decoding.py
@@ -17,7 +17,8 @@ from pyrallis.utils import (
     is_tuple,
     is_union,
     is_enum,
-    ParsingError
+    ParsingError,
+    format_error
 )
 
 logger = getLogger(__name__)
@@ -67,7 +68,7 @@ def decode_dataclass(
             raise e
         except Exception as e:
             raise ParsingError(
-                f"Failed when parsing value='{raw_value}' into field \"{cls}.{name}\" of type {field.type}.\n\tUnderlying error: {e}")
+                f"Failed when parsing value='{raw_value}' into field \"{cls}.{name}\" of type {field.type}.\n\tUnderlying error is \"{format_error(e)}\"")
 
         if field.init:
             init_args[name] = field_value

--- a/pyrallis/parsers/encoding.py
+++ b/pyrallis/parsers/encoding.py
@@ -103,7 +103,7 @@ def encode_dict(obj: Mapping) -> Dict[Any, Any]:
 
 @encode.register(Enum)
 def encode_enum(obj: Enum) -> str:
-    return obj.value
+    return obj.name
 
 
 for t in [str, float, int, bool, bytes]:

--- a/pyrallis/utils.py
+++ b/pyrallis/utils.py
@@ -581,6 +581,13 @@ def remove_matching(dict_a, dict_b):
     return deflatten(dict_a)
 
 
+def format_error(e: Exception):
+    try:
+        return f'{type(e).__name__}: {e}'
+    except Exception:
+        return f'Exception: {e}'
+
+
 CONFIG_ARG = 'config_path'
 
 if __name__ == "__main__":

--- a/tests/test_choice.py
+++ b/tests/test_choice.py
@@ -1,15 +1,15 @@
 from builtins import TypeError
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, auto
 
 from tests.testutils import *
 
 
 class Color(Enum):
-    blue: str = "blue"
-    red: str = "red"
-    green: str = "green"
-    orange: str = "orange"
+    blue: str = auto()
+    red: str = auto()
+    green: str = auto()
+    orange: str = auto()
 
 
 def test_passing_enum_to_choice():

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -1,15 +1,17 @@
 from dataclasses import dataclass, field
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from enum import Enum, auto
 
 from pyrallis.utils import PyrallisException
-
-import pyrallis
 from .testutils import *
 
 
+class Color(Enum):
+    blue: str = auto()
+    red: str = auto()
+
+
 def test_encode_something(simple_attribute):
-    some_type, passed_value, expected_value = simple_attribute
+    some_type, _, expected_value = simple_attribute
 
     @dataclass
     class SomeClass:
@@ -26,7 +28,7 @@ def test_encode_something(simple_attribute):
 
 
 def test_dump_load(simple_attribute, tmp_path):
-    some_type, passed_value, expected_value = simple_attribute
+    some_type, _, expected_value = simple_attribute
 
     @dataclass
     class SomeClass:
@@ -49,6 +51,19 @@ def test_dump_load(simple_attribute, tmp_path):
     assert new_b == b
 
 
+def test_dump_load_enum(tmp_path):
+    @dataclass
+    class SomeClass:
+        color: Color = Color.red
+
+    b = SomeClass()
+    tmp_file = tmp_path / 'config.yaml'
+    pyrallis.dump(b, tmp_file.open('w'))
+
+    new_b = pyrallis.parse(config_class=SomeClass, config_path=tmp_file, args="")
+    assert new_b == b
+
+
 def test_reserved_config_word():
     @dataclass
     class MainClass:
@@ -56,6 +71,7 @@ def test_reserved_config_word():
 
     with raises(PyrallisException):
         pyrallis.parse(MainClass)
+
 
 def test_super_nesting():
     @dataclass


### PR DESCRIPTION
Changed enum parsing to be based on enum field names instead of values.

As discussed in #8, this allows one to support enums with non-string values such as
```python
class LRMethod1(Enum):
    onecycle: torch.optim.lr_scheduler = OneCycleLR
    lambdalr: torch.optim.lr_scheduler = LambdaLR
```

Instead of allowing only enums of the form:
```python
class LRMethod2(Enum):
    onecycle: str = "onecycle"
    constant: str = "constant"
```