### PR TITLE
Improved Decoding Mechanism :microscope:

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -176,19 +176,20 @@ Where `#!python pyrallis.decode(TrainConfig, d)` will generate the matching data
 #### pyrallis.decode.register
 
 ```python
-def register(cls, func)
+def register(cls, func, with_subclasses=False)
 ```
 Pyrallis can decode many different types, but there's still a chance you might want to a type that isn't already built-in into pyrallis. This can be easily done using the register mechanism.
 
-??? "The @singledispatch wrapper"
+??? "The @withregistry wrapper"
 
-    The register method is a result of using the @singledispatch wrapper over the pyrallis.decode function, allowing to override it with new decoders.
+    The register method is a result of using the @withregistry wrapper over the pyrallis.decode function, a variant for pyrallis of the @singledispatch that only creates a registry and does not override the default entrypoint.
 
 
 > Parameters
 
 * **cls** - The type to register
 * **func** - The decoding function to register
+* **with_subclasses** - Whether to also register the function for the `cls` subclasses. If True, `func` will also expect the type parameter.
 
 > Returns
 
@@ -211,6 +212,14 @@ The register function can also be used as a wrapper
 def decode_array(x):
     return np.asarray(x)
 ```
+
+For inherited types one can either register it directly, or register a parent class
+```python
+pyrallis.decode.register(SomeClass, lambda x: SomeClass(x))
+# or
+pyrallis.decode.register(BaseClass, lambda t, x: t(x), with_subclasses=True)
+```
+Where `t` would be some subclass of `BaseClass`.
 
 ### pyrallis.encode
 ```python

--- a/pyrallis/parsers/decoding.py
+++ b/pyrallis/parsers/decoding.py
@@ -21,6 +21,7 @@ from pyrallis.utils import (
     format_error,
     has_generic_arg,
     withregistry,
+    RegistryFunc
 )
 
 logger = getLogger(__name__)
@@ -32,8 +33,8 @@ Dataclass = TypeVar("Dataclass")
 
 
 @withregistry
-def decode(t: Type[T], raw_value: Any) -> T:
-    return get_decoding_fn(t)(raw_value)
+def decode(cls: Type[T], raw_value: Any) -> T:
+    return get_decoding_fn(cls)(raw_value)
 
 
 # Dictionary mapping from types/type annotations to their decoding functions.
@@ -106,7 +107,7 @@ def decode_field(field: Field, raw_value: Any) -> Any:
 
 
 @lru_cache(maxsize=100)
-def get_decoding_fn(t: Type[T]) -> Callable[[Any], T]:
+def get_decoding_fn(cls: Type[T]) -> Callable[[Any], T]:
     """Fetches/Creates a decoding function for the given type annotation.
 
     This decoding function can then be used to create an instance of the type
@@ -119,44 +120,44 @@ def get_decoding_fn(t: Type[T]) -> Callable[[Any], T]:
 
     """
     # Start by trying the dispatch mechanism
-    cached_func = decode.dispatch(t)
+    cached_func: RegistryFunc = decode.dispatch(cls)
     if cached_func is not None:
-        if cached_func.pass_type:
-            return partial(cached_func.func, t)
+        if cached_func.pass_cls:
+            return partial(cached_func.func, cls)
         else:
             return cached_func.func
 
-    elif is_dataclass(t):
-        return partial(decode_dataclass, t)
+    elif is_dataclass(cls):
+        return partial(decode_dataclass, cls)
 
-    elif t is Any:
-        logger.debug(f"Decoding an Any type: {t}")
+    elif cls is Any:
+        logger.debug(f"Decoding an Any type: {cls}")
         return no_op
 
-    elif is_dict(t):
-        logger.debug(f"Decoding a Dict field: {t}")
-        args = get_type_arguments(t)
+    elif is_dict(cls):
+        logger.debug(f"Decoding a Dict field: {cls}")
+        args = get_type_arguments(cls)
         if args is None or len(args) != 2 or has_generic_arg(args):
             args = (Any, Any)
         return decode_dict(*args)
 
-    elif is_set(t):
-        logger.debug(f"Decoding a Set field: {t}")
-        args = get_type_arguments(t)
+    elif is_set(cls):
+        logger.debug(f"Decoding a Set field: {cls}")
+        args = get_type_arguments(cls)
         if args is None or len(args) != 1 or has_generic_arg(args):
             args = (Any,)
         return decode_set(args[0])
 
-    elif is_tuple(t):
-        logger.debug(f"Decoding a Tuple field: {t}")
-        args = get_type_arguments(t)
+    elif is_tuple(cls):
+        logger.debug(f"Decoding a Tuple field: {cls}")
+        args = get_type_arguments(cls)
         if args is None:
             args = []
         return decode_tuple(*args)
 
-    elif is_list(t):  # NOTE: Looks like can't be written with a dictionary
-        logger.debug(f"Decoding a List field: {t}")
-        args = get_type_arguments(t)
+    elif is_list(cls):  # NOTE: Looks like can't be written with a dictionary
+        logger.debug(f"Decoding a List field: {cls}")
+        args = get_type_arguments(cls)
         if args is None or len(args) != 1 or has_generic_arg(args):
             # Using a `List` or `list` annotation, so we don't know what do decode the
             # items into!
@@ -165,23 +166,23 @@ def get_decoding_fn(t: Type[T]) -> Callable[[Any], T]:
 
         return decode_fn
 
-    elif is_union(t):
-        logger.debug(f"Decoding a Union field: {t}")
-        args = get_type_arguments(t)
+    elif is_union(cls):
+        logger.debug(f"Decoding a Union field: {cls}")
+        args = get_type_arguments(cls)
         return decode_union(*args)
 
-    elif is_enum(t):
-        return lambda key: t[key]
+    elif is_enum(cls):
+        return lambda key: cls[key]
 
     import typing_inspect as tpi
 
-    if tpi.is_typevar(t):
-        bound = tpi.get_bound(t)
-        logger.debug(f"Decoding a typevar: {t}, bound type is {bound}.")
+    if tpi.is_typevar(cls):
+        bound = tpi.get_bound(cls)
+        logger.debug(f"Decoding a typevar: {cls}, bound type is {bound}.")
         if bound is not None:
             return get_decoding_fn(bound)
 
-    raise Exception(f"No decoding function for type {t}, consider using pyrallis.decode.register")
+    raise Exception(f"No decoding function for type {cls}, consider using pyrallis.decode.register")
 
     # Alternatively could have tried type as constructor, but could have a surprising behaviour
     # return try_constructor(t)

--- a/pyrallis/parsers/decoding.py
+++ b/pyrallis/parsers/decoding.py
@@ -7,6 +7,7 @@ from functools import partial
 from logging import getLogger
 from typing import TypeVar, Any, Dict, Type, Callable, Optional, Union, List, Tuple, Set
 
+from pyrallis.parsers.registry_utils import RegistryFunc, withregistry
 from pyrallis.utils import (
     get_type_arguments,
     is_dict,
@@ -17,9 +18,7 @@ from pyrallis.utils import (
     is_enum,
     ParsingError,
     format_error,
-    has_generic_arg,
-    withregistry,
-    RegistryFunc
+    has_generic_arg
 )
 
 logger = getLogger(__name__)
@@ -120,7 +119,8 @@ def get_decoding_fn(cls: Type[T]) -> Callable[[Any], T]:
     # Start by trying the dispatch mechanism
     cached_func: RegistryFunc = decode.dispatch(cls)
     if cached_func is not None:
-        if cached_func.pass_cls:
+        # If supports subclasses, pass the actual type
+        if cached_func.with_subclasses:
             return partial(cached_func.func, cls)
         else:
             return cached_func.func

--- a/pyrallis/parsers/registry_utils.py
+++ b/pyrallis/parsers/registry_utils.py
@@ -1,0 +1,81 @@
+from abc import get_cache_token
+from dataclasses import dataclass
+from functools import _find_impl, update_wrapper
+from typing import Callable, Optional
+
+
+@dataclass
+class RegistryFunc:
+    # The function saved in the registry
+    func: Callable
+    # Whether the function should be registered for subclasses as well
+    with_subclasses: bool
+
+
+def withregistry(base_func):
+    import types, weakref
+
+    registry = {}
+    dispatch_cache = weakref.WeakKeyDictionary()
+    cache_token = None
+
+    def dispatch(cls) -> Optional[RegistryFunc]:
+        nonlocal cache_token
+        if cache_token is not None:
+            current_token = get_cache_token()
+            if cache_token != current_token:
+                dispatch_cache.clear()
+                cache_token = current_token
+        if cls in dispatch_cache:
+            impl = dispatch_cache[cls]
+        else:
+            if cls in registry:
+                impl = registry[cls]
+            else:
+                try:
+                    impl: Optional[RegistryFunc] = _find_impl(cls, registry)
+                    if not impl.with_subclasses:
+                        # Do not allow implicit inherited implementation without type
+                        impl = None
+                except Exception:
+                    impl = None
+            dispatch_cache[cls] = impl
+
+        return impl
+
+    def register(cls, func=None, with_subclasses=False):
+        nonlocal cache_token
+        if func is None:
+            if isinstance(cls, type):
+                return lambda f: register(cls, func=f, with_subclasses=with_subclasses)
+            ann = getattr(cls, '__annotations__', {})
+            if not ann:
+                raise TypeError(
+                    f"Invalid first argument to `register()`: {cls!r}. "
+                    f"Use either `@register(some_class)` or plain `@register` "
+                    f"on an annotated function."
+                )
+            func = cls
+
+            # only import typing if annotation parsing is necessary
+            from typing import get_type_hints
+            argname, cls = next(iter(get_type_hints(func).items()))
+            assert isinstance(cls, type), (
+                f"Invalid annotation for {argname!r}. {cls!r} is not a class."
+            )
+        registry[cls] = RegistryFunc(func, with_subclasses)
+        if cache_token is None and hasattr(cls, '__abstractmethods__'):
+            cache_token = get_cache_token()
+        dispatch_cache.clear()
+        return func
+
+    def wrapper(*args, **kw):
+        # Unlike singledispatch we do not directly override the base call
+        return base_func(*args, **kw)
+
+    wrapper.register = register
+    wrapper.dispatch = dispatch
+    wrapper.registry = types.MappingProxyType(registry)
+    wrapper._clear_cache = dispatch_cache.clear
+    update_wrapper(wrapper, base_func)
+    return wrapper

--- a/pyrallis/utils.py
+++ b/pyrallis/utils.py
@@ -1,14 +1,11 @@
 """Utility functions used in various parts of the pyrallis package."""
-import argparse
 import builtins
 import collections.abc as c_abc
 import dataclasses
 import enum
-import functools
 import inspect
 import logging
 from abc import get_cache_token
-from collections import OrderedDict
 from dataclasses import _MISSING_TYPE, dataclass
 from enum import Enum
 from functools import _find_impl, update_wrapper
@@ -51,22 +48,10 @@ builtin_types = [
     if isinstance(getattr(builtins, d), type)
 ]
 
-K = TypeVar("K")
 T = TypeVar("T")
-U = TypeVar("U")
-V = TypeVar("V")
-W = TypeVar("W")
 
 Dataclass = TypeVar("Dataclass")
 DataclassType = Type[Dataclass]
-
-SimpleValueType = Union[bool, int, float, str]
-SimpleIterable = Union[
-    List[SimpleValueType], Dict[Any, SimpleValueType], Set[SimpleValueType]
-]
-
-TRUE_STRINGS: List[str] = ["yes", "true", "t", "y", "1"]
-FALSE_STRINGS: List[str] = ["no", "false", "f", "n", "0"]
 
 
 class PyrallisException(Exception):
@@ -77,23 +62,6 @@ class ParsingError(PyrallisException):
     pass
 
 
-def str2bool(raw_value: Union[str, bool]) -> bool:
-    """
-    Taken from https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse
-    """
-    if isinstance(raw_value, bool):
-        return raw_value
-    v = raw_value.strip().lower()
-    if v in TRUE_STRINGS:
-        return True
-    elif v in FALSE_STRINGS:
-        return False
-    else:
-        raise argparse.ArgumentTypeError(
-            f"Boolean value expected for argument, received '{raw_value}'"
-        )
-
-
 def get_item_type(container_type: Type[Container[T]]) -> T:
     """Returns the `type` of the items in the provided container `type`.
 
@@ -101,41 +69,6 @@ def get_item_type(container_type: Type[Container[T]]) -> T:
     `typing.Any`.
     NOTE: If a type with multiple arguments is passed, only the first type
     argument is returned.
-
-    >>> import typing
-    >>> from typing import List, Tuple
-    >>> get_item_type(list)
-    typing.Any
-    >>> get_item_type(List)
-    typing.Any
-    >>> get_item_type(tuple)
-    typing.Any
-    >>> get_item_type(Tuple)
-    typing.Any
-    >>> get_item_type(List[int])
-    <class 'int'>
-    >>> get_item_type(List[str])
-    <class 'str'>
-    >>> get_item_type(List[float])
-    <class 'float'>
-    >>> get_item_type(List[float])
-    <class 'float'>
-    >>> get_item_type(List[Tuple])
-    typing.Tuple
-    >>> get_item_type(List[Tuple[int, int]])
-    typing.Tuple[int, int]
-    >>> get_item_type(Tuple[int, str])
-    <class 'int'>
-    >>> get_item_type(Tuple[str, int])
-    <class 'str'>
-    >>> get_item_type(Tuple[str, str, str, str])
-    <class 'str'>
-
-    Arguments:
-        list_type {Type} -- A type, preferably one from the Typing module (List, Tuple, etc).
-
-    Returns:
-        Type -- the type of the container's items, if found, else Any.
     """
     if container_type in {
         list,
@@ -157,31 +90,6 @@ def get_item_type(container_type: Type[Container[T]]) -> T:
         return Any
 
 
-def get_argparse_type_for_container(
-        container_type: Type,
-) -> Union[Type, Callable[[str], bool]]:
-    """Gets the argparse 'type' option to be used for a given container type.
-    When an annotation is present, the 'type' option of argparse is set to that type.
-    if not, then the default value of 'str' is returned.
-
-    Arguments:
-        container_type {Type} -- A container type (ideally a typing.Type such as List, Tuple, along with an item annotation: List[str], Tuple[int, int], etc.)
-
-    Returns:
-        typing.Type -- the type that should be used in argparse 'type' argument option.
-
-    TODO: This overlaps in a weird way with `get_parsing_fn`, which returns the 'type'
-    to use for a given annotation! This function however doesn't deal with 'weird' item
-    types, it just returns the first annotation.
-    """
-    T = get_item_type(container_type)
-    if T is bool:
-        return str2bool
-    if T is Any:
-        return str
-    return T
-
-
 def _mro(t: Type) -> List[Type]:
     # TODO: This is mostly used in 'is_tuple' and such, and should be replaced with
     # either the build-in 'get_origin' from typing, or from typing-inspect.
@@ -197,136 +105,21 @@ def _mro(t: Type) -> List[Type]:
 
 
 def is_list(t: Type) -> bool:
-    """returns True when `t` is a List type.
-
-    Args:
-        t (Type): a type.
-
-    Returns:
-        bool: True if `t` is list or a subclass of list.
-
-    >>> from typing import *
-    >>> is_list(list)
-    True
-    >>> is_list(tuple)
-    False
-    >>> is_list(List)
-    True
-    >>> is_list(List[int])
-    True
-    >>> is_list(List[Tuple[int, str, None]])
-    True
-    >>> is_list(Optional[List[int]])
-    False
-    >>> class foo(List[int]):
-    ...   pass
-    ...
-    >>> is_list(foo)
-    True
-    """
     return list in _mro(t)
 
 
 def is_tuple(t: Type) -> bool:
-    """returns True when `t` is a tuple type.
-
-    Args:
-        t (Type): a type.
-
-    Returns:
-        bool: True if `t` is tuple or a subclass of tuple.
-
-    >>> from typing import *
-    >>> is_tuple(list)
-    False
-    >>> is_tuple(tuple)
-    True
-    >>> is_tuple(Tuple)
-    True
-    >>> is_tuple(Tuple[int])
-    True
-    >>> is_tuple(Tuple[int, str, None])
-    True
-    >>> class foo(tuple):
-    ...   pass
-    ...
-    >>> is_tuple(foo)
-    True
-    >>> is_tuple(List[int])
-    False
-    """
     return tuple in _mro(t)
 
 
 def is_dict(t: Type) -> bool:
-    """returns True when `t` is a dict type or annotation.
-
-    Args:
-        t (Type): a type.
-
-    Returns:
-        bool: True if `t` is dict or a subclass of dict.
-
-    >>> from typing import *
-    >>> from collections import OrderedDict
-    >>> is_dict(dict)
-    True
-    >>> is_dict(OrderedDict)
-    True
-    >>> is_dict(tuple)
-    False
-    >>> is_dict(Dict)
-    True
-    >>> is_dict(Dict[int, float])
-    True
-    >>> is_dict(Dict[Any, Dict])
-    True
-    >>> is_dict(Optional[Dict])
-    False
-    >>> is_dict(Mapping[str, int])
-    True
-    >>> class foo(Dict):
-    ...   pass
-    ...
-    >>> is_dict(foo)
-    True
-    """
     mro = _mro(t)
     return dict in mro or Mapping in mro or c_abc.Mapping in mro
 
 
 def is_set(t: Type) -> bool:
-    """returns True when `t` is a set type or annotation.
-
-    Args:
-        t (Type): a type.
-
-    Returns:
-        bool: True if `t` is set or a subclass of set.
-
-    >>> from typing import *
-    >>> is_set(set)
-    True
-    >>> is_set(Set)
-    True
-    >>> is_set(tuple)
-    False
-    >>> is_set(Dict)
-    False
-    >>> is_set(Set[int])
-    True
-    >>> is_set(Set["something"])
-    True
-    >>> is_set(Optional[Set])
-    False
-    >>> class foo(Set):
-    ...   pass
-    ...
-    >>> is_set(foo)
-    True
-    """
     mro = _mro(t)
-    return set in _mro(t)
+    return set in mro
 
 
 def is_dataclass_type(t: Type) -> bool:
@@ -358,51 +151,10 @@ def is_tuple_or_list(t: Type) -> bool:
 
 
 def is_union(t: Type) -> bool:
-    """Returns wether or not the given Type annotation is a variant (or subclass) of typing.Union
-
-    Args:
-        t (Type): some type annotation
-
-    Returns:
-        bool: Wether this type represents a Union type.
-
-    >>> from typing import *
-    >>> is_union(Union[int, str])
-    True
-    >>> is_union(Union[int, str, float])
-    True
-    >>> is_union(Tuple[int, str])
-    False
-    """
     return getattr(t, "__origin__", "") == Union
 
 
 def is_homogeneous_tuple_type(t: Type[Tuple]) -> bool:
-    """Returns wether the given Tuple type is homogeneous: if all items types are the
-    same.
-
-    This also includes Tuple[<some_type>, ...]
-
-    Returns
-    -------
-    bool
-
-    >>> from typing import *
-    >>> is_homogeneous_tuple_type(Tuple)
-    True
-    >>> is_homogeneous_tuple_type(Tuple[int, int])
-    True
-    >>> is_homogeneous_tuple_type(Tuple[int, str])
-    False
-    >>> is_homogeneous_tuple_type(Tuple[int, str, float])
-    False
-    >>> is_homogeneous_tuple_type(Tuple[int, ...])
-    True
-    >>> is_homogeneous_tuple_type(Tuple[Tuple[int, str], ...])
-    True
-    >>> is_homogeneous_tuple_type(Tuple[List[int], List[str]])
-    False
-    """
     if not is_tuple(t):
         return False
     type_arguments = get_type_arguments(t)
@@ -411,38 +163,11 @@ def is_homogeneous_tuple_type(t: Type[Tuple]) -> bool:
     assert isinstance(type_arguments, tuple), type_arguments
     if len(type_arguments) == 2 and type_arguments[1] is Ellipsis:
         return True
-    # Tuple[str, str, str] -> True
-    # Tuple[str, str, float] -> False
     # TODO: Not sure if this will work with more complex item times (like nested tuples)
     return len(set(type_arguments)) == 1
 
 
 def is_optional(t: Type) -> bool:
-    """Returns True if the given Type is a variant of the Optional type.
-
-    Parameters
-    ----------
-    - t : Type
-
-        a Type annotation (or "live" type)
-
-    Returns
-    -------
-    bool
-        Wether or not this is an Optional.
-
-    >>> from typing import Union, Optional, List
-    >>> is_optional(str)
-    False
-    >>> is_optional(Optional[str])
-    True
-    >>> is_optional(Union[str, None])
-    True
-    >>> is_optional(Union[str, List])
-    False
-    >>> is_optional(Union[str, List, int, float, None])
-    True
-    """
     return is_union(t) and type(None) in get_type_arguments(t)
 
 
@@ -527,22 +252,6 @@ def get_defaults_dict(c: Dataclass):
 
 
 def keep_keys(d: Dict, keys_to_keep: Iterable[str]) -> Tuple[Dict, Dict]:
-    """Removes all the keys in `d` that aren't in `keys`.
-
-    Parameters
-    ----------
-    d : Dict
-        Some dictionary.
-    keys_to_keep : Iterable[str]
-        The set of keys to keep
-
-    Returns
-    -------
-    Tuple[Dict, Dict]
-        The same dictionary (with all the unwanted keys removed) as well as a
-        new dict containing only the removed item.
-
-    """
     d_keys = set(d.keys())  # save a copy since we will modify the dict.
     removed = {}
     for key in d_keys:
@@ -604,10 +313,13 @@ def has_generic_arg(args):
             return True
     return False
 
+
 @dataclass
-class CachedFunc:
-    func : Callable
-    pass_type : bool
+class RegistryFunc:
+    # The function saved in the registry
+    func: Callable
+    # Whether the function expects the type to be passed
+    pass_cls: bool
 
 
 def withregistry(base_func):
@@ -617,7 +329,7 @@ def withregistry(base_func):
     dispatch_cache = weakref.WeakKeyDictionary()
     cache_token = None
 
-    def dispatch(cls) -> CachedFunc:
+    def dispatch(cls) -> Optional[RegistryFunc]:
         nonlocal cache_token
         if cache_token is not None:
             current_token = get_cache_token()
@@ -631,14 +343,17 @@ def withregistry(base_func):
                 impl = registry[cls]
             else:
                 try:
-                    impl = _find_impl(cls, registry)
+                    impl : Optional[RegistryFunc] = _find_impl(cls, registry)
+                    if not impl.pass_cls:
+                        # Do not allow implicit inherited implementation without type
+                        impl = None
                 except Exception:
                     impl = None
             dispatch_cache[cls] = impl
 
         return impl
 
-    def register(cls, func=None, pass_type=False):
+    def register(cls, func=None, pass_cls=False):
         nonlocal cache_token
         if func is None:
             if isinstance(cls, type):
@@ -658,13 +373,14 @@ def withregistry(base_func):
             assert isinstance(cls, type), (
                 f"Invalid annotation for {argname!r}. {cls!r} is not a class."
             )
-        registry[cls] = CachedFunc(func, pass_type)
+        registry[cls] = RegistryFunc(func, pass_cls)
         if cache_token is None and hasattr(cls, '__abstractmethods__'):
             cache_token = get_cache_token()
         dispatch_cache.clear()
         return func
 
     def wrapper(*args, **kw):
+        # Unlike singledispatch we do not directly override the base call
         return base_func(*args, **kw)
 
     wrapper.register = register
@@ -674,13 +390,6 @@ def withregistry(base_func):
     update_wrapper(wrapper, base_func)
     return wrapper
 
-
-def has_multiple_args(func):
-    from inspect import signature
-    try:
-        return len(signature(func).parameters) > 1
-    except Exception:
-        return False
 
 
 CONFIG_ARG = 'config_path'

--- a/pyrallis/utils.py
+++ b/pyrallis/utils.py
@@ -5,14 +5,11 @@ import dataclasses
 import enum
 import inspect
 import logging
-from abc import get_cache_token
-from dataclasses import _MISSING_TYPE, dataclass
+from dataclasses import _MISSING_TYPE
 from enum import Enum
-from functools import _find_impl, update_wrapper
 from logging import getLogger
 from typing import (
     Any,
-    Callable,
     Container,
     Dict,
     Iterable,
@@ -313,84 +310,6 @@ def has_generic_arg(args):
         if is_generic_arg(arg):
             return True
     return False
-
-
-@dataclass
-class RegistryFunc:
-    # The function saved in the registry
-    func: Callable
-    # Whether the function expects the type to be passed
-    pass_cls: bool
-
-
-def withregistry(base_func):
-    import types, weakref
-
-    registry = {}
-    dispatch_cache = weakref.WeakKeyDictionary()
-    cache_token = None
-
-    def dispatch(cls) -> Optional[RegistryFunc]:
-        nonlocal cache_token
-        if cache_token is not None:
-            current_token = get_cache_token()
-            if cache_token != current_token:
-                dispatch_cache.clear()
-                cache_token = current_token
-        if cls in dispatch_cache:
-            impl = dispatch_cache[cls]
-        else:
-            if cls in registry:
-                impl = registry[cls]
-            else:
-                try:
-                    impl : Optional[RegistryFunc] = _find_impl(cls, registry)
-                    if not impl.pass_cls:
-                        # Do not allow implicit inherited implementation without type
-                        impl = None
-                except Exception:
-                    impl = None
-            dispatch_cache[cls] = impl
-
-        return impl
-
-    def register(cls, func=None, pass_cls=False):
-        nonlocal cache_token
-        if func is None:
-            if isinstance(cls, type):
-                return lambda f: register(cls, f)
-            ann = getattr(cls, '__annotations__', {})
-            if not ann:
-                raise TypeError(
-                    f"Invalid first argument to `register()`: {cls!r}. "
-                    f"Use either `@register(some_class)` or plain `@register` "
-                    f"on an annotated function."
-                )
-            func = cls
-
-            # only import typing if annotation parsing is necessary
-            from typing import get_type_hints
-            argname, cls = next(iter(get_type_hints(func).items()))
-            assert isinstance(cls, type), (
-                f"Invalid annotation for {argname!r}. {cls!r} is not a class."
-            )
-        registry[cls] = RegistryFunc(func, pass_cls)
-        if cache_token is None and hasattr(cls, '__abstractmethods__'):
-            cache_token = get_cache_token()
-        dispatch_cache.clear()
-        return func
-
-    def wrapper(*args, **kw):
-        # Unlike singledispatch we do not directly override the base call
-        return base_func(*args, **kw)
-
-    wrapper.register = register
-    wrapper.dispatch = dispatch
-    wrapper.registry = types.MappingProxyType(registry)
-    wrapper._clear_cache = dispatch_cache.clear
-    update_wrapper(wrapper, base_func)
-    return wrapper
-
 
 
 CONFIG_ARG = 'config_path'


### PR DESCRIPTION
Improved decoding mechanism to support inherited types, one can still use the existing `register` functionality
```python
pyrallis.decode.register(SomeClass, lambda x: SomeClass(x))
```
But can also register parent classes as well
```python
pyrallis.decode.register(BaseClass, lambda t, x: t(x), with_subclasses=True)
```

Also revised the dispatch mechanism from singledispatch to a new dedicated wrapper (singledispatch tries to dispatch by class instead of value which isn't suited for decoding)
