### PR TITLE
Support Jsonnet as a config format

### DIFF
--- a/pyrallis/options.py
+++ b/pyrallis/options.py
@@ -7,7 +7,7 @@ from pyrallis.parsers.config_parsers import ParserEnum, YAMLParser, JSONParser, 
 class ConfigType(ParserEnum):
     YAML = YAMLParser
     JSON = JSONParser
-    JSONNET = JSONETParser
+    JSONNET = JSONNETParser
     TOML = TOMLParser
 
 

--- a/pyrallis/options.py
+++ b/pyrallis/options.py
@@ -1,7 +1,7 @@
 import contextlib
 from typing import Union
 
-from pyrallis.parsers.config_parsers import ParserEnum, YAMLParser, JSONParser, JSONETParser, TOMLParser
+from pyrallis.parsers.config_parsers import ParserEnum, YAMLParser, JSONParser, JSONNETParser, TOMLParser
 
 
 class ConfigType(ParserEnum):

--- a/pyrallis/options.py
+++ b/pyrallis/options.py
@@ -1,12 +1,13 @@
 import contextlib
 from typing import Union
 
-from pyrallis.parsers.config_parsers import ParserEnum, YAMLParser, JSONParser, TOMLParser
+from pyrallis.parsers.config_parsers import ParserEnum, YAMLParser, JSONParser, JSONETParser, TOMLParser
 
 
 class ConfigType(ParserEnum):
     YAML = YAMLParser
     JSON = JSONParser
+    JSONNET = JSONETParser
     TOML = TOMLParser
 
 

--- a/pyrallis/parsers/config_parsers.py
+++ b/pyrallis/parsers/config_parsers.py
@@ -69,6 +69,24 @@ class JSONParser(Parser):
             return json.dump(d, stream, **kwargs)
 
 
+class JSONNETParser(Parser):
+
+    @staticmethod
+    def parse_string(s):
+        import json
+        import _jsonnet
+        try:
+            s = _jsonnet.evaluate_snippet("snippet", s)  # "snippet" is a dummy filename parameter
+            return json.loads(s)
+        except json.decoder.JSONDecodeError:
+            return s  # No parsing to be done, simply return value
+
+    @staticmethod
+    def load_config(stream):
+        s = stream.read()  # Jsonnet doesn't provide stream API
+        return self.parse_string(s)
+
+
 class TOMLParser(Parser):
 
     @staticmethod

--- a/pyrallis/parsers/config_parsers.py
+++ b/pyrallis/parsers/config_parsers.py
@@ -69,7 +69,7 @@ class JSONParser(Parser):
             return json.dump(d, stream, **kwargs)
 
 
-class JSONNETParser(Parser):
+class JSONNETParser(JSONParser):
 
     @staticmethod
     def parse_string(s):
@@ -84,7 +84,7 @@ class JSONNETParser(Parser):
     @staticmethod
     def load_config(stream):
         s = stream.read()  # Jsonnet doesn't provide stream API
-        return self.parse_string(s)
+        return JSONNETParser.parse_string(s)
 
 
 class TOMLParser(Parser):

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -30,7 +30,7 @@ def test_encode_something(simple_attribute):
     assert pyrallis.decode(SomeClass, pyrallis.encode(b)) == b
 
 
-@parametrize('config_type', ['', 'yaml', 'json', 'toml'])
+@parametrize('config_type', ['', 'yaml', 'json', 'jsonnet', 'toml'])
 def test_dump_load(simple_attribute, config_type, tmp_path):
     some_type, _, expected_value = simple_attribute
 


### PR DESCRIPTION
Added support to the [jsonnet](https://jsonnet.org/) format which is a powerful superset on top of json. Jsonnet adds variables, conditionals, arithmetic, and more to the abilities of json.